### PR TITLE
Add initial React UI tests

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: ['@babel/preset-env', '@babel/preset-react']
+};

--- a/client/src/__tests__/DateSelector.test.js
+++ b/client/src/__tests__/DateSelector.test.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import DateSelector from '../components/DateSelector';
+
+describe('DateSelector', () => {
+  it('calls onDateChange when date is changed', () => {
+    const handleChange = jest.fn();
+    const { getByLabelText } = render(
+      <DateSelector selectedDate="2023-01-01" onDateChange={handleChange} />
+    );
+
+    fireEvent.change(getByLabelText(/Analysis Date/i), {
+      target: { value: '2023-01-02' }
+    });
+
+    expect(handleChange).toHaveBeenCalledWith('2023-01-02');
+  });
+});

--- a/client/src/__tests__/IndexSelector.test.js
+++ b/client/src/__tests__/IndexSelector.test.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import IndexSelector from '../components/IndexSelector';
+
+describe('IndexSelector', () => {
+  it('calls onIndexChange when NASDAQ radio is clicked', () => {
+    const handleChange = jest.fn();
+    const { getByDisplayValue } = render(
+      <IndexSelector selectedIndex="sp500" onIndexChange={handleChange} />
+    );
+
+    fireEvent.click(getByDisplayValue('nasdaq'));
+    expect(handleChange).toHaveBeenCalledWith('nasdaq');
+  });
+});

--- a/client/src/__tests__/UnifiedStockCard.test.js
+++ b/client/src/__tests__/UnifiedStockCard.test.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import UnifiedStockCard from '../components/UnifiedStockCard';
+
+describe('UnifiedStockCard', () => {
+  it('displays ticker and current price', () => {
+    const stock = {
+      ticker: 'AAPL',
+      change: 1.23,
+      priceBeforeEarnings: 100,
+      priceNow: 110,
+      marketCap: 2000000000
+    };
+
+    const { getByText } = render(
+      <UnifiedStockCard stock={stock} rank={1} type="gainer" />
+    );
+
+    expect(getByText('AAPL')).toBeInTheDocument();
+    expect(getByText('$110.00')).toBeInTheDocument();
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  transform: {
+    '^.+\\.(js|jsx)$': 'babel-jest'
+  },
+  moduleFileExtensions: ['js', 'jsx'],
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js']
+};

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest",
     "start": "export GOOGLE_APPLICATION_CREDENTIALS=\"./gcs-key.json\" && node server.js",
     "build": "webpack --mode production",
     "build:dev": "webpack --mode development",
@@ -37,7 +37,11 @@
     "style-loader": "^3.3.0",
     "webpack": "^5.88.0",
     "webpack-cli": "^5.1.0",
-    "webpack-dev-server": "^5.2.1"
+    "webpack-dev-server": "^5.2.1",
+    "jest": "^29.6.0",
+    "babel-jest": "^29.6.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- add Jest and React Testing Library setup
- add simple tests for IndexSelector, DateSelector and UnifiedStockCard

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840b27b49a8832dac5f59965b9dda88