### PR TITLE
Add Yahoo redirect mitigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,15 @@ A modern financial platform that highlights S&P 500 & NASDAQ investment opportun
    FINNHUB_API_KEY=your_finnhub_api_key
    OPENAI_API_KEY=your_openai_api_key_here
    GCS_BUCKET=your_gcs_bucket_name_optional
+   # Optional: Yahoo consent cookie to avoid redirect issues
+   YAHOO_COOKIE=your_yahoo_cookie
    ```
-   Note: 
-   - The Finnhub API key is optional (a default is provided)
-   - The OpenAI API key is required for AI analysis features
-   - The GCS_BUCKET is optional for caching. If not provided, caching will be disabled and the app will work without Google Cloud Storage
+   Note:
+    - The Finnhub API key is optional (a default is provided)
+    - The OpenAI API key is required for AI analysis features
+    - The GCS_BUCKET is optional for caching. If not provided, caching will be disabled and the app will work without Google Cloud Storage
    - If using Google Cloud Storage, place your service account key file as `gcs-key.json` in the project root
+   - Set `YAHOO_COOKIE` if you see `Unexpected redirect` errors from Yahoo Finance (e.g. redirects to `?guccounter=1`)
 5. Start the server:
    ```sh
    npm start

--- a/services/marketCap.js
+++ b/services/marketCap.js
@@ -1,5 +1,22 @@
 // services/marketCap.js
 const yahooFinance = require('yahoo-finance2').default;
+
+// Optional consent cookie to bypass region redirect
+const YAHOO_COOKIE = process.env.YAHOO_COOKIE;
+if (YAHOO_COOKIE) {
+  try {
+    yahooFinance.setGlobalConfig({
+      cookie: YAHOO_COOKIE,
+      headers: {
+        'User-Agent': 'Mozilla/5.0',
+        'Accept-Language': 'en-US,en;q=0.9'
+      }
+    });
+    console.log('[CONFIG] Yahoo Finance cookie configured');
+  } catch (err) {
+    console.warn('[WARN] Failed to set Yahoo Finance cookie:', err.message);
+  }
+}
 const { readCache, writeCache } = require('../utils/cache');
 
 const MARKETCAP_CACHE_MS = 24 * 60 * 60 * 1000; // 1 day


### PR DESCRIPTION
## Summary
- configure `yahoo-finance2` with optional `YAHOO_COOKIE`
- document `YAHOO_COOKIE` env var for deploying in regions where Yahoo redirects to the consent page

## Testing
- `npm test` *(fails: no test specified)*
- `node test-buy-opportunities.js` *(fails: Cannot find module 'axios')*


------
https://chatgpt.com/codex/tasks/task_e_6844455bd68c832da4ca720c4492f165